### PR TITLE
Fix ansible apt module detects wrong cache mtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-add-repository -y ppa:ansible/ansible \
        ansible \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
+    && touch -m -t 200101010101.01 /var/lib/apt/lists \
     && apt-get clean
 
 # Install Ansible inventory file


### PR DESCRIPTION
apt-get update on Ubuntu 12.04 does not update the mtime for
/var/lib/apt/periodic/update-success-stamp (which is the primary file
that ansible's apt module uses to determine the last cache update time.
The fallback file that ansible uses is the mtime of /var/lib/apt/lists
so we touch that directory instead.